### PR TITLE
mention arista eos

### DIFF
--- a/README
+++ b/README
@@ -111,6 +111,7 @@ bin/
 	xilogin.in	Version of clogin.in for Xirrus arrays.
 lib/
 	acos.pm.in	rancid library for A10 Networks appliances.
+	aeos.pm.in	rancid library for Arista Networks EOS.
 	arbor.pm.in	rancid library for Arbor Networks appliances.
 	arcos.pm.in	rancid library for Arrcus Networks ArcOS.
 	ciscowlc.pm.in	rancid library for some Cisco Wireless Lan Controllers.

--- a/man/clogin.1
+++ b/man/clogin.1
@@ -52,8 +52,8 @@ router
 is an
 .BR expect (1)
 script to automate the process of logging into a Cisco router,
-Catalyst switch, Extreme switch, Juniper ERX/E-series, Procket Networks,
-or Redback router.
+Catalyst switch, Arista switch, Extreme switch, Juniper ERX/E-series,
+Procket Networks or Redback router.
 There are complementary scripts for
 A10,
 Alteon,

--- a/man/rancid.1
+++ b/man/rancid.1
@@ -74,10 +74,11 @@ F5 BigIPs
 .TP
 .B rancid
 The generic rancid script; supporting Allied Telesis AW+ devices,
-Arbor Networks Appliances, Ciena Waverserver, Cisco IOS, Cisco IOS-XR,
-Cisco NX-OS, Cisco WLC, (some) Dell switches, Extreme switches,
-Fortinet firewalls, Foundry (aka some Brocade) devices, Juniper JUNOS,
-Nokia (Alcatel-Lucent) SR OS, and UBNT Edgemax and EdgeRouter.
+Arbor Networks Appliances, Arista EOS, Ciena Waverserver, Cisco IOS,
+Cisco IOS-XR, Cisco NX-OS, Cisco WLC, (some) Dell switches,
+Extreme switches, Fortinet firewalls, Foundry (aka some Brocade)
+devices, Juniper JUNOS, Nokia (Alcatel-Lucent) SR OS, and UBNT
+Edgemax and EdgeRouter.
 It uses the device O/S modules for parsing routines as determined by the
 .BR rancid.types.conf (5)
 file(s).


### PR DESCRIPTION
arrancid seems to have gotten changed to a device module. arrancid was removed from this manpage, but arista eos wasn't added to the generic rancid list it seems.

(noticed while migrating aerohive/hiveos support in my forked repo)