### PR TITLE
Move rancid_intro(1) and lg_intro(1) to man section 7.

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -579,7 +579,7 @@ A. You should first search the rancid-discuss mail list and the web for
    someone.
 
    If you must write one, it is helpful to have a basic understanding of
-   rancid's general process.  See rancid_intro(1) and this maillist thread
+   rancid's general process.  See rancid_intro(7) and this maillist thread
    thread:
    http://www.shrubbery.net/pipermail/rancid-discuss/2015-August/008630.html .
 

--- a/README
+++ b/README
@@ -133,7 +133,7 @@ man/		man pages
 share/		Readmes, samples, utilities, contribs, etc
 include/	Include files and rancid's version.h
 
-Also see rancid_intro(1), rancid(1), and clogin(1).
+Also see rancid_intro(7), rancid(1), and clogin(1).
 
 The following (non-exhaustive list) are included as part of the installation
 and configuration tools:

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -11,7 +11,7 @@ AUTOMAKE_OPTIONS=foreign no-dependencies
 @SET_MAKE@
 
 man_gen_MANS = cloginrc.5 lg.conf.5 rancid.3 rancid.conf.5 \
-		rancid.types.conf.5 lg_intro.1
+		rancid.types.conf.5 lg_intro.7
 man_nogen_MANS = agmrancid.1 alogin.1 anlogin.1 \
 		arancid.1 avologin.1 avorancid.1 blogin.1 brancid.1 \
 		cat5rancid.1 clogin.1 control_rancid.1 csblogin.1 cssrancid.1 \
@@ -23,7 +23,7 @@ man_nogen_MANS = agmrancid.1 alogin.1 anlogin.1 \
 		nrancid.1 nslogin.1 nsrancid.1 \
 		panlogin.1 par.1 plogin.1 \
 		rancid-cvs.1 rancid-run.1 rancid.1 \
-		rancid.types.base.5 rancid_intro.1 rivlogin.1 rivrancid.1 \
+		rancid.types.base.5 rancid_intro.7 rivlogin.1 rivrancid.1 \
 		router.db.5 rrancid.1 tlogin.1 ulogin.1 wlogin.1 \
 		xilogin.1 xlogin.1 xirancid.1 trancid.1 \
 		zrancid.1
@@ -32,9 +32,9 @@ man_MANS = $(man_nogen_MANS) $(man_gen_MANS)
 
 EXTRA_DIST = $(man_nogen_MANS) $(man_gen_MANS:%=%.in)
 
-htmls_MANS = clogin.1 cloginrc.5 control_rancid.1 lg.conf.5 lg_intro.1 \
+htmls_MANS = clogin.1 cloginrc.5 control_rancid.1 lg.conf.5 lg_intro.7 \
 	par.1 rancid-cvs.1 rancid-run.1 rancid.1 rancid.3 \
-	rancid.conf.5 rancid.types.conf.5 rancid_intro.1 router.db.5
+	rancid.conf.5 rancid.types.conf.5 rancid_intro.7 router.db.5
 htmls_gen_MANS= $(htmls_MANS:%=%.html)
 
 CLEANFILES = $(man_gen_MANS) $(htmls_gen_MANS)
@@ -71,10 +71,10 @@ lg.conf.5: Makefile $(srcdir)/lg.conf.5.in
 	$(auto_edit) $(srcdir)/lg.conf.5.in >lg.conf.5.tmp; \
 	mv lg.conf.5.tmp lg.conf.5
 
-lg_intro.1: Makefile $(srcdir)/lg_intro.1.in
-	rm -f lg_intro.1 lg_intro.1.tmp; \
-	$(auto_edit) $(srcdir)/lg_intro.1.in >lg_intro.1.tmp; \
-	mv lg_intro.1.tmp lg_intro.1
+lg_intro.7: Makefile $(srcdir)/lg_intro.7.in
+	rm -f lg_intro.7 lg_intro.7.tmp; \
+	$(auto_edit) $(srcdir)/lg_intro.7.in >lg_intro.7.tmp; \
+	mv lg_intro.7.tmp lg_intro.7
 
 rancid.conf.5: Makefile $(srcdir)/rancid.conf.5.in
 	rm -f rancid.conf.5 rancid.conf.5.tmp; \

--- a/man/Makefile.in
+++ b/man/Makefile.in
@@ -146,9 +146,10 @@ am__uninstall_files_from_dir = { \
   }
 man1dir = $(mandir)/man1
 am__installdirs = "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man3dir)" \
-	"$(DESTDIR)$(man5dir)"
+	"$(DESTDIR)$(man5dir)" "$(DESTDIR)$(man7dir)"
 man3dir = $(mandir)/man3
 man5dir = $(mandir)/man5
+man7dir = $(mandir)/man7
 NROFF = nroff
 MANS = $(man_MANS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
@@ -277,7 +278,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
 man_gen_MANS = cloginrc.5 lg.conf.5 rancid.3 rancid.conf.5 \
-		rancid.types.conf.5 lg_intro.1
+		rancid.types.conf.5 lg_intro.7
 
 man_nogen_MANS = agmrancid.1 alogin.1 anlogin.1 \
 		arancid.1 avologin.1 avorancid.1 blogin.1 brancid.1 \
@@ -290,16 +291,16 @@ man_nogen_MANS = agmrancid.1 alogin.1 anlogin.1 \
 		nrancid.1 nslogin.1 nsrancid.1 \
 		panlogin.1 par.1 plogin.1 \
 		rancid-cvs.1 rancid-run.1 rancid.1 \
-		rancid.types.base.5 rancid_intro.1 rivlogin.1 rivrancid.1 \
+		rancid.types.base.5 rancid_intro.7 rivlogin.1 rivrancid.1 \
 		router.db.5 rrancid.1 tlogin.1 ulogin.1 wlogin.1 \
 		xilogin.1 xlogin.1 xirancid.1 trancid.1 \
 		zrancid.1
 
 man_MANS = $(man_nogen_MANS) $(man_gen_MANS)
 EXTRA_DIST = $(man_nogen_MANS) $(man_gen_MANS:%=%.in)
-htmls_MANS = clogin.1 cloginrc.5 control_rancid.1 lg.conf.5 lg_intro.1 \
+htmls_MANS = clogin.1 cloginrc.5 control_rancid.1 lg.conf.5 lg_intro.7 \
 	par.1 rancid-cvs.1 rancid-run.1 rancid.1 rancid.3 \
-	rancid.conf.5 rancid.types.conf.5 rancid_intro.1 router.db.5
+	rancid.conf.5 rancid.types.conf.5 rancid_intro.7 router.db.5
 
 htmls_gen_MANS = $(htmls_MANS:%=%.html)
 CLEANFILES = $(man_gen_MANS) $(htmls_gen_MANS)
@@ -481,6 +482,49 @@ uninstall-man5:
 	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^5][0-9a-z]*$$,5,;x' \
 	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
 	dir='$(DESTDIR)$(man5dir)'; $(am__uninstall_files_from_dir)
+install-man7: $(man_MANS)
+	@$(NORMAL_INSTALL)
+	@list1=''; \
+	list2='$(man_MANS)'; \
+	test -n "$(man7dir)" \
+	  && test -n "`echo $$list1$$list2`" \
+	  || exit 0; \
+	echo " $(MKDIR_P) '$(DESTDIR)$(man7dir)'"; \
+	$(MKDIR_P) "$(DESTDIR)$(man7dir)" || exit 1; \
+	{ for i in $$list1; do echo "$$i"; done;  \
+	if test -n "$$list2"; then \
+	  for i in $$list2; do echo "$$i"; done \
+	    | sed -n '/\.7[a-z]*$$/p'; \
+	fi; \
+	} | while read p; do \
+	  if test -f $$p; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; echo "$$p"; \
+	done | \
+	sed -e 'n;s,.*/,,;p;h;s,.*\.,,;s,^[^7][0-9a-z]*$$,7,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,' | \
+	sed 'N;N;s,\n, ,g' | { \
+	list=; while read file base inst; do \
+	  if test "$$base" = "$$inst"; then list="$$list $$file"; else \
+	    echo " $(INSTALL_DATA) '$$file' '$(DESTDIR)$(man7dir)/$$inst'"; \
+	    $(INSTALL_DATA) "$$file" "$(DESTDIR)$(man7dir)/$$inst" || exit $$?; \
+	  fi; \
+	done; \
+	for i in $$list; do echo "$$i"; done | $(am__base_list) | \
+	while read files; do \
+	  test -z "$$files" || { \
+	    echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(man7dir)'"; \
+	    $(INSTALL_DATA) $$files "$(DESTDIR)$(man7dir)" || exit $$?; }; \
+	done; }
+
+uninstall-man7:
+	@$(NORMAL_UNINSTALL)
+	@list=''; test -n "$(man7dir)" || exit 0; \
+	files=`{ for i in $$list; do echo "$$i"; done; \
+	l2='$(man_MANS)'; for i in $$l2; do echo "$$i"; done | \
+	  sed -n '/\.7[a-z]*$$/p'; \
+	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^7][0-9a-z]*$$,7,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
+	dir='$(DESTDIR)$(man7dir)'; $(am__uninstall_files_from_dir)
 tags TAGS:
 
 ctags CTAGS:
@@ -525,7 +569,7 @@ check-am: all-am
 check: check-am
 all-am: Makefile $(MANS)
 installdirs:
-	for dir in "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man3dir)" "$(DESTDIR)$(man5dir)"; do \
+	for dir in "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man3dir)" "$(DESTDIR)$(man5dir)" "$(DESTDIR)$(man7dir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -595,7 +639,7 @@ install-info: install-info-am
 
 install-info-am:
 
-install-man: install-man1 install-man3 install-man5
+install-man: install-man1 install-man3 install-man5 install-man7
 
 install-pdf: install-pdf-am
 
@@ -625,7 +669,8 @@ ps-am:
 
 uninstall-am: uninstall-man
 
-uninstall-man: uninstall-man1 uninstall-man3 uninstall-man5
+uninstall-man: uninstall-man1 uninstall-man3 uninstall-man5 \
+	uninstall-man7
 
 .MAKE: install-am install-strip
 
@@ -635,12 +680,12 @@ uninstall-man: uninstall-man1 uninstall-man3 uninstall-man5
 	install-data-am install-dvi install-dvi-am install-exec \
 	install-exec-am install-html install-html-am install-info \
 	install-info-am install-man install-man1 install-man3 \
-	install-man5 install-pdf install-pdf-am install-ps \
-	install-ps-am install-strip installcheck installcheck-am \
-	installdirs maintainer-clean maintainer-clean-generic \
-	mostlyclean mostlyclean-generic pdf pdf-am ps ps-am tags-am \
-	uninstall uninstall-am uninstall-man uninstall-man1 \
-	uninstall-man3 uninstall-man5
+	install-man5 install-man7 install-pdf install-pdf-am \
+	install-ps install-ps-am install-strip installcheck \
+	installcheck-am installdirs maintainer-clean \
+	maintainer-clean-generic mostlyclean mostlyclean-generic pdf \
+	pdf-am ps ps-am tags-am uninstall uninstall-am uninstall-man \
+	uninstall-man1 uninstall-man3 uninstall-man5 uninstall-man7
 
 .PRECIOUS: Makefile
 
@@ -663,10 +708,10 @@ lg.conf.5: Makefile $(srcdir)/lg.conf.5.in
 	$(auto_edit) $(srcdir)/lg.conf.5.in >lg.conf.5.tmp; \
 	mv lg.conf.5.tmp lg.conf.5
 
-lg_intro.1: Makefile $(srcdir)/lg_intro.1.in
-	rm -f lg_intro.1 lg_intro.1.tmp; \
-	$(auto_edit) $(srcdir)/lg_intro.1.in >lg_intro.1.tmp; \
-	mv lg_intro.1.tmp lg_intro.1
+lg_intro.7: Makefile $(srcdir)/lg_intro.7.in
+	rm -f lg_intro.7 lg_intro.7.tmp; \
+	$(auto_edit) $(srcdir)/lg_intro.7.in >lg_intro.7.tmp; \
+	mv lg_intro.7.tmp lg_intro.7
 
 rancid.conf.5: Makefile $(srcdir)/rancid.conf.5.in
 	rm -f rancid.conf.5 rancid.conf.5.tmp; \

--- a/man/lg.conf.5.in
+++ b/man/lg.conf.5.in
@@ -167,7 +167,7 @@ installed, in that order.
 .El
 .SH "SEE ALSO"
 .BR cloginrc (5),
-.BR lg_intro (1),
+.BR lg_intro (7),
 .BR router.db (5)
 .\"
 .SH HISTORY

--- a/man/lg_intro.7.in
+++ b/man/lg_intro.7.in
@@ -1,6 +1,6 @@
 .\"
 .hys 50
-.TH "lg_intro" "1" "24 Jan 2001"
+.TH "lg_intro" "7" "24 Jan 2001"
 .SH NAME
 lg_intro \- introduction to the looking glass
 .\"

--- a/man/rancid_intro.7
+++ b/man/rancid_intro.7
@@ -1,6 +1,6 @@
 .\"
 .hys 50
-.TH "rancid_intro" "1" "12 July 2019"
+.TH "rancid_intro" "7" "12 July 2019"
 .SH NAME
 rancid_intro \- introduction to the Really Awesome New Cisco confIg Differ
 .SH INTRODUCTION
@@ -134,7 +134,7 @@ Update the system's mail aliases file
 .BR clogin (1),
 .BR cloginrc (5),
 .BR control_rancid (1),
-.BR lg_intro (1),
+.BR lg_intro (7),
 .BR rancid (1),
 .BR rancid-run (1),
 .BR rancid.conf (5),

--- a/share/rancid.spec
+++ b/share/rancid.spec
@@ -106,7 +106,7 @@ rm -rf $RPM_BUILD_ROOT
 %files lg
 %defattr(-,root,root,0755)
 %config(noreplace) /etc/lg.conf
-%{_mandir}/man1/lg_intro*
+%{_mandir}/man7/lg_intro*
 %{_mandir}/man5/lg.conf*
 /var/www/cgi-bin/*
 %doc README.lg


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man7/man-pages.7.html only the man pages of of user commands should be placed in man section 1.
Sor rancid_intro(1) and lg_intro(7) should be moved to section 7 which is the place for "Overview, conventions, and miscellaneous".

This patch moves the two man pages from section 1 to 7 and tries to fix all pointers and links accordingly.