### PR TITLE
control_rancid:  Add '--porcelain' flag to 'git status'

### DIFF
--- a/bin/control_rancid.in
+++ b/bin/control_rancid.in
@@ -504,7 +504,7 @@ for router in `cut -d\; -f1 ../routers.up` ; do
 	if [ ! -f $router ] ; then
 	    touch $router
 	fi
-	git status $router | grep '^?' > /dev/null 2>&1
+	git status --porcelain $router | grep '^?' > /dev/null 2>&1
 	if [ $? -eq 0 ] ; then
 	    git add $router
 	    git commit -m 'new router' $router


### PR DESCRIPTION
The 'git status' command needs the '--short' or '--porcelain' flags for the
untracked files to start with a '?' character.

From the 'man git-status' output,'--porcelain' is identical to '--short' but is
guaranteed not to change in the future, making it safe for scripts.

Below is an example of 'git status' without and with the --porcelain flag:

```
jude@pwan:~/projects/rancid (master % u=)$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

        blah

nothing added to commit but untracked files present (use "git add" to track)
jude@pwan:~/projects/rancid (master % u=)$ git status --porcelain
?? blah
```