### PR TITLE
dnos10.pm: filter fan speed for second fan on same tray

### DIFF
--- a/lib/dnos10.pm.in
+++ b/lib/dnos10.pm.in
@@ -144,18 +144,24 @@ REDO:	last if (/$prompt/);
 	    ProcessHistory("COMMENTS","keysort","C1","! $_");
 	    # FanTray  Status      AirFlow   Fan  Speed(rpm)  Status
 	    # ----------------------------------------------------------------
-	    # 1        up          REVERSE   1    11160       up         
+	    # 1        up          REVERSE   1    8520        up         
+	    #                                2    7680        up         
 	    while (<$INPUT>) {
 		s/^\s+\015//g;
 		tr/\015//d;
 		last if (/$prompt/);
 		last if (/^-- /);		# next section
-		/^\s*$/ && next;
 		if (/^(\d+\s+\w+\s+\w+\s+\d+\s+)(\d+)(\s+\w+)\s*$/) {
 		    my($sl) = length($2);
                     my($fmt) = "%s%-". $sl ."s%s\n";
                     $_ = sprintf($fmt, $1, "", $3);
 		}
+		elsif (/^(\s+\d+\s+)(\d+)(\s+\w+)\s*$/) {
+		    my($sl) = length($2);
+                    my($fmt) = "%s%-". $sl ."s%s\n";
+                    $_ = sprintf($fmt, $1, "", $3);
+		}
+		/^\s*$/ && next;
 		ProcessHistory("COMMENTS","keysort","C1","! $_");
 	    }
 	    goto REDO;


### PR DESCRIPTION
This patches `dnos10.pm` to filter out the fan speed if there's a second fan for any specify fan tray present, e.g. on S5200 devices such as the S5232F and S5248F where raw data might look like this:

```
-- Fan Status --
FanTray  Status      AirFlow   Fan  Speed(rpm)  Status
----------------------------------------------------------------
1        up          REVERSE   1    8520        up         
                               2    7680        up         
                               
2        up          REVERSE   1    8640        up         
                               2    7680        up         
                               
3        up          REVERSE   1    8640        up         
                               2    7680        up         
                               
4        up          REVERSE   1    8520        up         
                               2    7800        up         
```