### PR TITLE
Add subroutine to parse "show inventory media" on dnos10 devices

### DIFF
--- a/etc/rancid.types.base
+++ b/etc/rancid.types.base
@@ -401,6 +401,7 @@ dnos10;command;rancid::RunCommand;terminal length 0
 dnos10;command;dnos10::ShowSys;show system
 dnos10;command;dnos10::ShowVer;show version
 dnos10;command;dnos10::ShowInventory;show inventory
+dnos10;command;dnos10::ShowInventoryMedia;show inventory media
 dnos10;command;dnos10::ShowVlan;show vlan
 dnos10;command;dnos10::WriteTerm;show running-configuration
 #

--- a/lib/dnos10.pm.in
+++ b/lib/dnos10.pm.in
@@ -189,6 +189,26 @@ sub ShowInventory {
     return(0);
 }
 
+# This routine parses "show inventory media"
+sub ShowInventoryMedia {
+    my($INPUT, $OUTPUT, $cmd) = @_;
+    print STDERR "    In ShowInventoryMedia: $_" if ($debug);
+
+    while (<$INPUT>) {
+	tr/\015//d;
+	last if (/^$prompt/);
+	next if (/^(\s*|\s*$cmd\s*)$/);
+	next if (/^(\s*System Inventory Media\s*)$/);
+	return(1) if /(Invalid input|Type help or )/;
+	return(-1) if (/command authorization failed/i);
+
+	/-----------------------------/ && next;
+	ProcessHistory("COMMENTS","keysort","INVENTORYMEDIA","!Inventory: $_");
+    }
+    ProcessHistory("COMMENTS","keysort","INVENTORYMEDIA","!\n");
+    return(0);
+}
+
 sub ShowVlan {
     my($INPUT, $OUTPUT, $cmd) = @_;
     print STDERR "    In ShowVlan: $_" if ($debug);


### PR DESCRIPTION
This adds a subroutine to parse "show inventory media" on dnos10 similarly to ios, aeos, etc.