### PR TITLE
dnos10.pm: fix typo

### DIFF
--- a/lib/dnos10.pm.in
+++ b/lib/dnos10.pm.in
@@ -5,7 +5,7 @@ package dnos10;
 #
 #  RANCID - Really Awesome New Cisco confIg Differ
 #
-#  dnos9.pm - Dell NOS10 rancid procedures - from Bjørn Skobba
+#  dnos10.pm - Dell NOS10 rancid procedures - from Bjørn Skobba
 
 use 5.010;
 use strict 'vars';


### PR DESCRIPTION
Fixes a simple typo in `lib/dnos10.pm.in`