### PR TITLE
Man page fixup (.ID, .El, .Bl, .Pp)

### DIFF
--- a/man/clogin.1
+++ b/man/clogin.1
@@ -258,7 +258,6 @@ Specifies the encryption algorithm for use with the
 \-c option.  The default encryption type is often not supported.  See the
 .BR ssh (1)
 man page for details.  The default is 3des.
-.El
 .\"
 .SH RETURNS
 If the login script fails for any of the devices on the command-line, the
@@ -299,7 +298,6 @@ HOME is used by
 to locate the
 .IR .cloginrc
 configuration file.
-.El
 .SH FILES
 .ta \w'xHOME/xcloginrc  'u 
 \fI$HOME/.cloginrc\fR   Configuration file.

--- a/man/cloginrc.5.in
+++ b/man/cloginrc.5.in
@@ -322,7 +322,6 @@ file that is shared among a group of folks.
 If <file> is not a full pathname, $HOME/ will be prepended.
 .sp
 Example: include {.cloginrc.group}
-.El
 .SH FILES
 .br
 .nf

--- a/man/lg.conf.5.in
+++ b/man/lg.conf.5.in
@@ -14,7 +14,6 @@ resources.
 .\"
 .SH VARIABLES
 The following variables are used (alphabetically):
-.Bl -tag -width flag
 .\"
 .TP
 .B LG_AS_REG
@@ -135,10 +134,8 @@ note that it must include $BASEDIR/bin (see above).
 .TP
 Queries		...................................
 .\"
-.El
 .\"
 .SH ENVIRONMENT
-.Bl -tag -width LG_CONF -compact
 .TP
 .B LG_CONF
 Location of
@@ -146,7 +143,6 @@ Location of
 file.  See the
 .IR FILES
 section for more information.
-.El
 .\"
 .SH ERRORS
 .B lg.conf
@@ -155,7 +151,6 @@ is interpreted directly by
 so its syntax follows that of perl.  Syntax errors may produce quite unexpected
 results.
 .SH FILES
-.Bl -tag -width @sysconfdir@/rancid.conf -compact
 .TP
 .B @sysconfdir@/lg.conf
 Configuration file described here.
@@ -164,7 +159,6 @@ Configuration file described here.
 is located by the value of the environment variable LG_CONF, in the CWD
 (current working directory), or the sysconfdir defined when rancid was
 installed, in that order.
-.El
 .SH "SEE ALSO"
 .BR cloginrc (5),
 .BR lg_intro (7),

--- a/man/par.1
+++ b/man/par.1
@@ -136,7 +136,6 @@ options and the option appearing last will take precedence.
 .B \-x
 View par logs in real-time via an 
 .BR xterm (1).
-.El
 .SH FILES
 .br
 .nf
@@ -165,5 +164,4 @@ received a HUP/INT/TERM/QUIT signal, it does not exit immediately after
 sending kill to running jobs.  it waits for them to exit so that they are
 cleaned-up properly.
 If a second signal is received, it dies immediately.
-.El
 

--- a/man/rancid-run.1
+++ b/man/rancid-run.1
@@ -134,7 +134,6 @@ device with 'clogin hostname', and so on.
 .B $BASEDIR/etc/rancid.conf
 .B rancid-run
 configuration file.
-.El
 .SH "SEE ALSO"
 .BR control_rancid (1),
 .BR rancid.conf (5),

--- a/man/rancid.1
+++ b/man/rancid.1
@@ -175,7 +175,7 @@ If stored locally, the file changes constantly and causes constant diffs
 from rancid.
 If this file's name ('ip dhcp database') matches the regex
 dhcp_[^[:space:].]\.txt, it will be filtered.
-.Pp
+.PP
 For Catalyst switches running CatOS, type
 .B cat5,
 the prompt must end with '>'.

--- a/man/rancid.conf.5.in
+++ b/man/rancid.conf.5.in
@@ -27,7 +27,6 @@ The following variables are used (listed alphabetically):
 .\"
 .TP
 .B ACLFILTERSEQ
-.Bl -tag -width flag
 Disables filtering of prefix-list/access-list sequence numbers.
 This option implies ACLSORT=NO for lists with sequence numbers.
 .sp
@@ -312,14 +311,12 @@ is interpreted directly by
 so its syntax follows that of the bourne shell.  Errors
 may produce quite unexpected results.
 .SH FILES
-.Bl -tag -width @sysconfdir@/rancid.conf -compact
 .TP
 .B @sysconfdir@/rancid.conf
 Configuration file described here.
 .TP
 .B <group>/rancid.conf
 Group-specific configuration file described here.
-.El
 .\"
 .SH "SEE ALSO"
 .BR control_rancid (1),

--- a/man/rancid.types.conf.5.in
+++ b/man/rancid.types.conf.5.in
@@ -106,14 +106,12 @@ In general, the default 90 seconds, but some modules themselves alter this.
 .\"
 .PP
 .SH FILES
-.Bl -tag -width @sysconfdir@/rancid.types.conf -compact
 .TP
 .B @sysconfdir@/rancid.types.conf
 Configuration file described here.
 .TP
 .B @sysconfdir@/rancid.types.base
 Configuration file described here.
-.El
 .\"
 .SH "SEE ALSO"
 .BR control_rancid (1),

--- a/man/router.db.5
+++ b/man/router.db.5
@@ -48,85 +48,66 @@ Domain Name) works best, as in the example above.
 The type of device from the set:
 .RS 8n
 .TP
-.ID 15n
 .B agm
 A Cisco Anomaly Guard Module (aka Riverhead).
 Suspect that at some point the UI will become more cisco-like and it
 can be merged with the IOS rancid module.
 .TP
-.ID 15n
 .B alteon
 An Alteon WebOS switches.
 .TP
-.ID 15n
 .B arcos
 An Arrcus router.
 .TP
-.ID 15n
 .B arista
 An Arista Networks device.
 .TP
-.ID 15n
 .B baynet
 A Bay Networks router.
 .TP
-.ID 15n
 .B bigip
 A F5 device running BIG-IP >= v11.
 .TP
-.ID 15n
 .B cat5
 A Cisco catalyst series 5000 and 4000 switches (i.e.: running the catalyst OS,
 not IOS).
 .TP
-.ID 15n
 .B ciena-ws
 A Ciena Waveserver.
 .TP
-.ID 15n
 .B cisco
 A Cisco router, PIX, or switch such as the 3500XL or 6000 running IOS (or
 IOS-like) OS, but not IOS-XR, NX-OS or Cisco small business devices.
 .TP
-.ID 15n
 .B cisco-sb
 A Cisco small business devices.
 .TP
-.ID 15n
 .B cisco-nx
 A Cisco Nexus switch/router.
 .TP
-.ID 15n
 .B cisco-xr
 A Cisco device running IOS-XR.
 .TP
-.ID 15n
 .B cisco-wlc4
 A Cisco Wireless Controller versions up to 4.
 .TP
-.ID 15n
 .B cisco-wlc5
 A Cisco Wireless Controller versions 5 and above.
 .TP
-.ID 15n
 .B css
 A Cisco content services switch.
 .TP
-.ID 15n
 .B enterasys
 An enterasys NAS.  This is currently an alias for the
 .B riverstone
 device type.
 .TP
-.ID 15n
 .B erx
 A Juniper E-series edge router.
 .TP
-.ID 15n
 .B fss2
 A Fujitsu FSS2/1finity device.
 .TP
-.ID 15n
 .B dell
 A Dell switch.
 Known working models are DES-3010F, DES-3052P, DES-3526, and DES-3550.
@@ -134,41 +115,32 @@ Note that Dell OEMs some equipment and has purchased some companies, so a
 Dell product may not work with the dell rancid module but may work with
 smc or force10.
 .TP
-.ID 15n
 .B extreme
 An Extreme switch.
 .TP
-.ID 15n
 .B ezt3
 An ADC-Kentrox EZ-T3 mux.
 .TP
-.ID 15n
 .B f5
 A F5 BigIP switch.
 .TP
-.ID 15n
 .B force10
 A Force10 router.
 .TP
-.ID 15n
 .B fortigate
 A Fortinet firewall.
 .TP
-.ID 15n
 .B fortigate-full
 A Fortinet firewall with all defaults shown.
 .TP
-.ID 15n
 .B foundry
 A Foundry router, switch, or router-switch.  This includes HP
 Procurve switches that are OEMs of Foundry products, such as the
 HP9304M.
 .TP
-.ID 15n
 .B hitachi
 A Hitachi router.
 .TP
-.ID 15n
 .B hp
 A HP Procurve switch such as the 2524, 4108 or J9086A (aka. 2610) procurve
 switches, J9091A, and J8698A.
@@ -176,7 +148,6 @@ Also see the
 .B foundry
 type.
 .TP
-.ID 15n
 .B juniper
 A Juniper router.
 .TP
@@ -187,44 +158,34 @@ A host running the (Merit) MRTd daemon.
 A MRV optical device; including NC316, OptiSwitch 904, OptiSwitch 906G,
 OptiSwitch 912C, OptiSwitch 940.
 .TP
-.ID 15n
 .B netscaler
 A Netscaler load balancer.
 .TP
-.ID 15n
 .B netscreen
 A Netscreen firewall.
 .TP
-.ID 15n
 .B paloalto
 A Palo Alto Networks device.
 .TP
-.ID 15n
 .B redback
 A Redback router, NAS, etc.
 .TP
-.ID 15n
 .B riverstone
 A Riverstone NAS or Cabletron (starting with version ~9.0.3) router.
 .TP
-.ID 15n
 .B routeros
 A Mikrotik RouterOS router.
 .TP
-.ID 15n
 .B smc
 A SMC switch, which also account for some Dell OEMs.
 Including Dell PowerConnect 35xx (3524, 3524P, 3548, 3548P) and 7048.
 .TP
-.ID 15n
 .B sros
 A Nokia (Alcatel-Lucent) router, such as the 7750 SR.
 .TP
-.ID 15n
 .B xirrus
 A Xirrus array.
 .TP
-.ID 15n
 .B zebra
 Zebra routing software.
 .RE
@@ -274,7 +235,6 @@ Configuration file described here, where <group> is a device group name
 defined in the variable
 .I LIST_OF_GROUPS
 within \fI$BASEDIR/etc/rancid.conf\fR.
-.El
 .SH "SEE ALSO"
 .BR control_rancid (1),
 .BR rancid (1),


### PR DESCRIPTION
When running 
`man --warnings -E UTF-8 -l -Tutf8 -Z manpage.man > /dev/null`
on all man pages in rancid on a Debian system, this results in several warnings like
```
warning: macro 'El' not defined
warning: macro 'Bl' not defined
warning: macro 'ID' not defined
warning: macro 'Pp' not defined
```
Here  .Pp seems to be a simple typo (should be .PP).

.El and .Bl are not defined in the standard man page macro set, but only in BSD -mdoc macro set, which isn't used in standard Linux man processing and if I fully understood the documentation, they always should be used as a .Bl / .El pair, which doesn't happen in the rancid man pages.  From my point of view, both can simply be removed from all man pages.

Last but not least router.db(5) uses ".ID 15n", which also isn't defined in the standard Linux man macro set, but can also be removed without loosing information.