### PR TITLE
Add diffstat output to rancid diffs

### DIFF
--- a/bin/control_rancid.in
+++ b/bin/control_rancid.in
@@ -718,6 +718,9 @@ if [ -s $TMP.diff ] ; then
 		echo "Commit message: $commitmsg"
 		echo ""
 	  fi
+	  if which diffstat >/dev/null ; then
+		diffstat $TMP.diff
+	  fi
 	  cat $TMP.diff
 	) | $SENDMAIL -t $MAILOPTS
     else


### PR DESCRIPTION
Years ago Christian Hammers <ch@debian.org> suggested in https://bugs.debian.org/357218 to add a diffstat output on top of the normal diff output. This gives a quick overview if any of "my" routers are affected or just those of my collegues etc...

I extended the call by a check whether diffstat is installed (and ignore otherwise) and this little patch is available in Debian since 2007, so it doesn't seem to hurt ;-)