### PR TITLE
Add new variable PRECOMMIT_HOOK

### DIFF
--- a/bin/control_rancid.in
+++ b/bin/control_rancid.in
@@ -38,9 +38,9 @@
 ## when in relation to etc/rancid.types.conf.  The goal of this is to help
 ## suppress our support costs.  If it becomes a problem, this could become a
 ## condition of license.
-# 
+#
 #  The expect login scripts were based on Erik Sherk's gwtn, by permission.
-# 
+#
 #  The original looking glass software was written by Ed Kern, provided by
 #  permission and modified beyond recognition.
 #
@@ -633,6 +633,11 @@ do
 	fi
     fi
 done
+
+# Custom adjustments on the configs
+if [ "X$PRECOMMIT_HOOK" != "X" ]; then
+  eval $PRECOMMIT_HOOK
+fi
 
 # This has been different for different machines...
 # Diff the directory and then checkin.

--- a/etc/rancid.conf.sample.in
+++ b/etc/rancid.conf.sample.in
@@ -106,6 +106,11 @@ RCSSYS=@RCSSYS@; export RCSSYS
 # more groups...
 #LIST_OF_GROUPS="$LIST_OF_GROUPS noc billybobisp"; export LIST_OF_GROUPS
 #
+# Define a command to execute after catching the configs and before committing
+# them to the RCS. This is aimed to allow changes on the configs, for example to
+# erase some parts of them and so avoid unecessary commits.
+#PRECOMMIT_HOOK="sed 's/foo/bar/g' -i configs/*"; export PRECOMMIT_HOOK
+#
 # Define an alternate filter for the output of the RCS diff.  The filter
 # should read from stdin and write to stdout.  The default is defined in
 # control_rancid and just improves readability.

--- a/lib/rancid.py.in
+++ b/lib/rancid.py.in
@@ -50,6 +50,7 @@ class RancidConf():
         self.OLDTIME = 4
         self.PAR_COUNT = 5
         self.PATH = "@bindir@:@ENV_PATH@"
+        self.PRECOMMIT_HOOK = None
         self.RCSSYS = "@RCSSYS@"
         self.SENDMAIL = "@SENDMAIL@"
         self.TERM = "network"
@@ -200,6 +201,8 @@ class RancidConf():
                     self.PAR_COUNT = val
                 elif var == "PATH":
                     self.PATH = val
+                elif var == "PRECOMMIT_HOOK":
+                    self.PRECOMMIT_HOOK = val
                 elif var == "RCSSYS":
                     self.RCSSYS = val
                 elif var == "SENDMAIL":

--- a/man/rancid.conf.5.in
+++ b/man/rancid.conf.5.in
@@ -260,6 +260,15 @@ Its value is set by configure.  Should it be necessary to modify PATH,
 note that it must include @bindir@.
 .\"
 .TP
+.B PRECOMMIT_HOOK
+Defines a command to execute after catching the configs and before committing
+them to the RCS. This is aimed to allow changes on the configs, for example to
+erase some parts of them and so avoid unecessary commits.
+.sp
+Example: PRECOMMIT_HOOK="sed '/^!Flash: nvram: .* total/d' -i configs/*";
+export PRECOMMIT_HOOK
+.\"
+.TP
 .B RCSSYS
 Sets which revision control system is in use.
 Valid values are


### PR DESCRIPTION
I'm proposing a new variable PRECOMMIT_HOOK, to let admins execute commands on the configs before the commit. I need this to avoid unecessary commits (with their mails), juste because the occupation of the nvram slightly changed.

Example of lines which can be annoying:
```
sed '/^!Flash: harddisk:.*total/d' -i configs/*
sed '/^!Flash: nvram:.*total/d' -i configs/*
sed '/^!\s\+Not ready set/d' -i configs/*
```

I currently cheat by doing that in a `DIFFSCRIPT` script, but it's not really appropriate.

Thanks for your work!