### PR TITLE
Update command use to save config in F5

### DIFF
--- a/etc/rancid.types.base
+++ b/etc/rancid.types.base
@@ -516,6 +516,8 @@ bigip;command;bigip::ShowLicense;tmsh show /sys license
 bigip;command;bigip::ShowZebOSconf;cat /config/ZebOS.conf
 bigip;command;bigip::ShowZebOSsockets;lsof -i :179
 bigip;command;bigip::ShowRouteStatic;tmsh show /net route static
+bigip;command;bigip::WriteTerm;tmsh save sys config file /tmp/rancid no-passphrase && cat /tmp/rancid && shred -u /tmp/rancid
+bigip;command;bigip::WriteTerm;tmsh save sys config file /tmp/rancid && cat /tmp/rancid && shred -u /tmp/rancid
 bigip;command;bigip::WriteTerm;tmsh -q list
 #
 # f5 big-ip v13

--- a/lib/bigip.pm.in
+++ b/lib/bigip.pm.in
@@ -19,6 +19,8 @@ use rancid @VERSION@;
 @ISA = qw(Exporter rancid main);
 #XXX @Exporter::EXPORT = qw($VERSION @commandtable %commands @commands);
 
+our $found_hardware;
+
 # load-time initialization
 sub import {
     # force a terminal type so as not to confuse the POS
@@ -34,6 +36,8 @@ sub init {
     ProcessHistory("COMMENTS","keysort","A1","#\n");
     ProcessHistory("COMMENTS","keysort","B0","#\n");
     ProcessHistory("COMMENTS","keysort","C0","#\n");
+
+    $found_hardware = 0;
 
     0;
 }
@@ -144,6 +148,7 @@ sub ShowHardware {
         return(1) if /^\s*\^\s*$/;
         return(1) if /(Invalid input detected|Type help or )/;
         return(-1) if (/command authorization failed/i);
+        return(0) if ($found_hardware);
 
         s/\d+rpm//ig;
         s/^\|//;
@@ -157,6 +162,7 @@ sub ShowHardware {
 
         ProcessHistory("COMMENTS","keysort","B1","#$_") && next;
     }
+    $found_hardware = 1;
     return(0);
 }
 
@@ -252,9 +258,14 @@ sub WriteTerm {
     my($lines) = 0;
     print STDERR "    In WriteTerm: $_" if ($debug);
 
+    ProcessHistory("","","","#\n");
     while (<$INPUT>) {
         tr/\015//d;
         next if (/^\s*$/);
+        return(0) if ($found_end);  # Only do this routine once
+        next if (/^(\s*|\s*$cmd\s*)$/);
+        return(1) if (/^Data Input Error:/);
+        return(1) if /(Invalid input detected|Type help or )/;
 
         # Ignore monitor down state, save the config as up.
         s/state down$/state up/i;


### PR DESCRIPTION
Change the command used to backup configuration on F5 device.
With these commands, we try:
- first, save the configuration with tmsh save
- second, same with others parameters
- last, the initial command.

With this commands, if you have multiple partitions, you can backup all the partitions in one command