### PR TITLE
Filter frequently changing ssd file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 3.99.99
+	ios.pm: filter frequently changing ssd file - Bart Bylemans
+
 	iosxr.pm: filter nvgen_bkup.log file timestamp
 
 	sros.pm: disable the progress indicator during collection

--- a/lib/ios.pm.in
+++ b/lib/ios.pm.in
@@ -1230,7 +1230,7 @@ sub DirSlotN {
 	# to:
 	#       -rw-                                   vlan.dat
 	#       -rw-                                           vlan.dat
-	if (/(dhcp_[^. ]*\.txt|vlan\.dat|\slog|sflog|snooping|syslog)\s*$/ ||
+	if (/(dhcp_[^. ]*\.txt|vlan\.dat|\slog|sflog|snooping|syslog|ssd)\s*$/ ||
 	    /(tracelogs|throughput_monitor_params|underlying-config)\s*$/) {
 	    if (/(\s*\d+\s+)(\S+\s+)(\d+)(\s+)(\w+ \d+\s+\d+ \d+:\d+:\d+ .\d+:\d+)/) {
 		my($fn, $a, $sz, $c, $dt, $rem) = ($1, $2, $3, $4, $5, $');


### PR DESCRIPTION
On the Cisco Catalyst 9k switches, starting from at least IOS XE v17.3.x, a file named 'ssd' can be found on the (boot)flash filesystem. The filename is an abbreviation for "secure storage disk" and this file is tied to the Guest Shell functionality for providing a virtualized Linux-based environment. However on some of the Catalyst 9k platforms (e.g. Catalyst 9500's) this file changes daily causing an unwanted diff.

Also see this [question](https://networkengineering.stackexchange.com/questions/78892/what-is-the-ssd-luks-file-on-the-bootflash-of-newer-9k-catalyst-switches/79012) on Network Engineering StackExchange for more information.