### PR TITLE
dnos10: remove fluctuating electrical info from "show system"

### DIFF
--- a/lib/dnos10.pm.in
+++ b/lib/dnos10.pm.in
@@ -119,6 +119,10 @@ REDO:	last if (/$prompt/);
 
 	# Remove Uptime
 	/^Up Time/i && next;
+	# Remove Voltage, Current, and Power
+	/^Voltage/ && next;
+	/^Current/ && next;
+	/^Power/ && next;
 
 	if (/-- power supplies --/i) {
 	    ProcessHistory("COMMENTS","keysort","C1","! $_");


### PR DESCRIPTION
"show system" includes lines like

```
Voltage              : 12   Volts
Current              : 4   Amps
Power                : 51  Watts
```
dnos10.pm already excludes /^Up Time/  from "show system"; these lines reporting electrical properties similarly just add fluctuating noise to rancid-generated commit histories.