### PR TITLE
get rid of grep warning

### DIFF
--- a/etc/rancid.conf.sample.in
+++ b/etc/rancid.conf.sample.in
@@ -33,7 +33,7 @@ PATH=@bindir@:@ENV_PATH@; export PATH
 # you are doing, disable this check by commenting these lines.
 uid=`perl -e 'print "$>"'`
 if [ -e /proc/1/cgroup ] ; then
-    DOCKER=`cat /proc/1/cgroup | grep "cpu.*\/docker"`
+    DOCKER=`cat /proc/1/cgroup | grep "cpu.*/docker"`
 fi
 test "x$DOCKER" = "x" && test "$uid" -eq 0 && echo "Do not run $0 as root!" && exit 1
 #


### PR DESCRIPTION
recent versions of gnu grep might complain if your regex makes no sense for the chosen engine
(basic, extended or perl). this was added around gnu grep 3.8

anyway, for the regular expression to check if we run under docker no flag is given so we run the basic regex engine, and in the basic engine forward slash has no special meaning and does not need to be escaped by a backslash.

gets rid of:
grep: warning: stray \ before /

egrep/fgrep are also on their last legs; see https://www.gnu.org/software/grep/manual/html_node/Usage.html item 17 & should be changed to grep -E / -F, warnings for not doing so might be added soon as well.