### PR TITLE
replacing Arista deprecated command

### DIFF
--- a/etc/rancid.types.base
+++ b/etc/rancid.types.base
@@ -74,7 +74,7 @@ arista;module;aeos
 arista;inloop;aeos::inloop
 arista;command;aeos::ShowVersion;show version
 arista;command;aeos::ShowBoot;show boot-config
-arista;command;aeos::ShowEnv;show env all
+arista;command;aeos::ShowEnv;show system environment all
 arista;command;aeos::ShowFlash;dir flash:
 arista;command;aeos::ShowInventory;show inventory
 arista;command;aeos::ShowBootExt;show boot-extensions


### PR DESCRIPTION
_show env all_ is deprecated and no longer works on Arista devices. The correct command is _show system environment all_ Please see: https://www.arista.com/en/um-eos/eos-environment-commands#xx1142616