### PR TITLE
fxlogin: Send an extra <ENTER> before exit to fix FXOS + ASA backups

### DIFF
--- a/bin/fxlogin.in
+++ b/bin/fxlogin.in
@@ -431,7 +431,7 @@ proc run_commands { prompt command } {
     }
 
     if { [string compare "extreme" "$platform"] } {
-	send -h "exit\r"
+	send -h "\rexit\r"
     } else {
 	send -h "quit\r"
     }


### PR DESCRIPTION
The issue is in the fxos.pm module though:

    sub WriteTerm {
    ...
    while (<$INPUT>) {
    ...
    return(0) if ($found_end); # Only do this routine once

WriteTerm() eats another line even though it found the end of the show config command

And that line is

    fw01-dist-3a-z-fx# exit

The exact same line that the inloop() function looks for to detect that we had a clean run.


The issue was reported before on the mailing list https://shrubbery.net/pipermail/rancid-discuss/2020-October/010985.html