### PR TITLE
Excluding oscillating entrys from config in iosxr.pm.in

### DIFF
--- a/lib/iosxr.pm.in
+++ b/lib/iosxr.pm.in
@@ -985,6 +985,8 @@ sub ShowLicense {
 	# filter the BS from license broker
 	next if (/(renewal attempt|communication attempt):/i);
 	next if (/next registration attempt:/i);		# timestamp
+ 	next if (/Registration Expires:/i);
+	next if (/Communication Deadline:/i);
 	next if (/(period used:|requested time:)/i);		# show lic feature
 	if (/(^\s*(evaluation )?period (left|remaining):\s*)\d+/i) {
 	    ProcessHistory("COMMENTS","keysort","LICENSE","! $1<limited>\n");


### PR DESCRIPTION
excluding Registration expiration and Communication deadline causing oscillation mentioned in issue #57