### PR TITLE
Remove timestamp lines from command "show mda detail" output

### DIFF
--- a/lib/sros.pm.in
+++ b/lib/sros.pm.in
@@ -352,6 +352,8 @@ TOP: while (<$INPUT>) {
 	next if (/^\s+\^$/);
 	return(-1) if (/error: invalid parameter/i);
 	return(-1) if (/minor: cli command not allowed for this user/i);
+	# remove timestamp
+    next if (/^\w{3} \w{3} +\d{1,2} \d{2}:\d{2}:\d{2} \w{3,4} \d{4}/);
 	# context lines
 	/^\[[^]]*]$/i && next;
 	/^$/i && next; # extra blank lines tr doesn't remove


### PR DESCRIPTION
Add regex to filter out timestamp lines from "show mad detail" output.