### PR TITLE
Filter out 'Free Space' and 'Percent Used' lines from "show card detail"

### DIFF
--- a/lib/sros.pm.in
+++ b/lib/sros.pm.in
@@ -136,8 +136,8 @@ sub ShowCardDetail {
 	return(-1) if (/error: invalid parameter/i);
 	return(-1) if (/minor: cli command not allowed for this user/i);
 	# remove "Free Space" and "Percent Used" lines
-	next if (/^\s*Free space\s+:\s+\d+\s*(KB|MB|GB)\s*$/); 
-	next if (/^\s*Percent Used\s+:\s+\d+\s*%\s*$/);
+	next if (/^\s*Free space\s+:\s+\d+\s*(KB|MB|GB)\s*\n?$/); 
+	next if (/^\s*Percent Used\s+:\s+\d+\s*%\s*\n?$/);
 	# context lines
 	/^\[[^]]*]$/i && next;
 

--- a/lib/sros.pm.in
+++ b/lib/sros.pm.in
@@ -135,6 +135,9 @@ sub ShowCardDetail {
 	next if (/^\s+\^$/);
 	return(-1) if (/error: invalid parameter/i);
 	return(-1) if (/minor: cli command not allowed for this user/i);
+	# remove "Free Space" and "Percent Used" lines
+	next if (/^\s*Free space\s+:\s+\d+\s*(KB|MB|GB)\s*$/); 
+	next if (/^\s*Percent Used\s+:\s+\d+\s*%\s*$/);
 	# context lines
 	/^\[[^]]*]$/i && next;
 


### PR DESCRIPTION
Exclude lines related to 'Free Space' and 'Percent Used' from processing from "show card details".