### PR TITLE
remove extraneous \ before / in grep command

### DIFF
--- a/bin/control_rancid.in
+++ b/bin/control_rancid.in
@@ -615,7 +615,7 @@ do
     if [ ! -s $router.new ] ; then
 	rm -f $router.new
     else
-	notcomment=`grep -Ev "^[-*\!\;#]|\/\*" $router.new | wc -l`
+	notcomment=`grep -Ev "^[-*\!\;#]|/\*" $router.new | wc -l`
 	if [ $notcomment -gt 10 ]; then
 	    lines=1;
 	else


### PR DESCRIPTION
Resolves this warning:

grep: warning: stray \ before /